### PR TITLE
Address small typo in `bvsge`

### DIFF
--- a/src/ap/theories/bitvectors/ModuloArithmetic.scala
+++ b/src/ap/theories/bitvectors/ModuloArithmetic.scala
@@ -156,7 +156,7 @@ object ModuloArithmetic extends Theory {
   def bvugt(t1 : ITerm, t2 : ITerm) : IFormula = bvult(t2, t1)
   def bvuge(t1 : ITerm, t2 : ITerm) : IFormula = bvule(t2, t1)
   def bvsgt(t1 : ITerm, t2 : ITerm) : IFormula = bvslt(t2, t1)
-  def bvsge(t1 : ITerm, t2 : ITerm) : IFormula = bvsge(t2, t1)
+  def bvsge(t1 : ITerm, t2 : ITerm) : IFormula = bvsle(t2, t1)
 
   def zero_extend(addWidth : Int, t : ITerm) : ITerm =
     IFunApp(zero_extend, List(extractBitWidth(t), addWidth, t))


### PR DESCRIPTION
`bvsge` was calling itself recursively with swapped arguments.