### PR TITLE
Add a top-level `isLit` check if simplifying `mod_cast`

### DIFF
--- a/src/main/scala/ap/theories/bitvectors/ModuloArithmetic.scala
+++ b/src/main/scala/ap/theories/bitvectors/ModuloArithmetic.scala
@@ -727,7 +727,7 @@ object ModuloArithmetic extends Theory {
 
   override def evalFun(f : IFunApp) : Option[ITerm] =
     if (f.args forall (isLit _)) {
-      if (f.fun == mod_cast) {
+      if (f.fun == mod_cast && isLit(f)) {
         // make sure that the value is in simplified form
         import IExpression._
         val IFunApp(_, Seq(IIntLit(lower), IIntLit(upper), IIntLit(value))) = f


### PR DESCRIPTION
See #19 for details and discussion.

PR implements the one-line fix.