### PR TITLE
Add gitignore, sbt version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*
+
+# build files
+target/
+.bloop
+.bsp
+.metals
+.vscode
+metals.sbt
+*.class
+*.log
+

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.11.3


### PR DESCRIPTION
Adds a gitignore and the autogenerated sbt version file that is created at each compile.

Allows working with princess using an IDE with git features.

**Before:**

Me: :cry:

VSCode:

<img width="49" height="52" alt="ss-2025-08-05_10:30:17" src="https://github.com/user-attachments/assets/eebec9b1-c870-4e88-aab3-5b58dedba2a6" />

<img width="470" height="118" alt="ss-2025-08-05_10:30:25" src="https://github.com/user-attachments/assets/2301e8a7-da1a-4c7a-b8d4-726d0d155503" /> 

**After:**

Me: :smile: 

VSCode:

<img width="53" height="59" alt="ss-2025-08-05_10:30:49" src="https://github.com/user-attachments/assets/71941a77-37dd-4242-b265-497226e0a9ba" />


