### PR TITLE
Add an extractor and name for SetSort

### DIFF
--- a/src/main/scala/ap/theories/arrays/SetTheory.scala
+++ b/src/main/scala/ap/theories/arrays/SetTheory.scala
@@ -75,6 +75,21 @@ object SetTheory {
     instances.getOrElseUpdate(elSort, new SetTheory(elSort))
   }
 
+  /**
+    * Extractor for set sorts of any base type.
+    */
+  object Sort {
+    def unapply(s : Sort) : Option[Sort] = s match {
+      case ps : Theory.TheorySort =>
+        ps.theory match {
+          case ss : SetTheory => Some(ss.elementSort)
+          case _              => None
+        }
+      case _ =>
+        None
+    }
+  }
+
 }
 
 /**
@@ -94,6 +109,8 @@ class SetTheory(val elementSort : Sort)
   object SetSort extends ProxySort(arTheory.sort) with Theory.TheorySort {
     import IExpression._
     val theory = SetTheory.this
+
+    override val name: String = s"Set[${elementSort.name}]"
 
     // TODO: implement further methods. In particular, we have to translate
     // back array terms to set terms, similar to how it is done in


### PR DESCRIPTION
I'm not pleased calling the extractor `SetTheory.Sort` but `SetTheory.SetSort` is taken. (suggestions welcome, of course)

This change allows using sets in Eldarica with a small patch as well.